### PR TITLE
Install guideline for OS X / macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ Not all hardware works perfectly with the Pi, so to save you some digging, here'
 
 ## Software
 
-Preparing the image is easy. Assuming you're on OS X:
+Preparing the image is easy. Assuming you're on macOS:
 
-1. `$ wget https://github.com/futurice/chilipie-kiosk/releases/download/v1.2.1/chilipie-kiosk-v1.2.1.img.zip`
-1. `$ unzip chilipie-kiosk-v1.2.1.img.zip`
+1. `$ curl -O -L https://github.com/futurice/chilipie-kiosk/releases/download/v1.2.1/chilipie-kiosk-v1.2.1.img.zip | unzip`
 1. Insert your microSD card
 1. `$ diskutil list` to check the correct device
 1. `$ diskutil unmountDisk /dev/disk2` to prepare it for imaging


### PR DESCRIPTION
Using wget as download method would never work on a clean macOS machine since it doesn't ship with wget (you'll need homebrew for wget).

Curl however, does come out of the box so I changed it to download over curl and unzip once completed.